### PR TITLE
Support Python >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
The project is tagged with python 3.6 and appears to work with that version just fine, but the python requirement is set to 3.8. 

Please let me know if there is any reason to not support the earlier version, but I'd love to use the latest updates in my python 3.7 project without forking the code :)